### PR TITLE
Fix log interpolation evaluation in trapezoidal rules

### DIFF
--- a/R/trap.r
+++ b/R/trap.r
@@ -20,30 +20,33 @@ trap <- function(x = NA, y = NA, method = 1){
   if (method == 1){
     z <- sum( (x-lag(x)) * (y+lag(y)) / 2, na.rm = T )
   }
-  if (method==2) {
-    z <- sum(
-      ifelse(
-        lag(y) > y & lag(y) > 0 & y > 0,
-        (x - lag(x)) * (y - lag(y)) / log(y/lag(y)), # See Rowland & Tozer 471
-        (x - lag(x)) * (y + lag(y)) / 2
-      ),
-      na.rm=T
-    )
+  if (method == 2) {
+    dx <- diff(x)
+    y2 <- y[-1]
+    y1 <- y[-length(y)]
+    down <- which(y1 > y2 & y1 > 0 & y2 > 0)
+    up   <- setdiff(seq_along(dx), down)
+    z <- 0
+    if (length(down)) {
+      z <- z + sum(dx[down] * (y2[down] - y1[down]) / log(y2[down]/y1[down]), na.rm = TRUE)
+    }
+    if (length(up)) {
+      z <- z + sum(dx[up] * (y2[up] + y1[up]) / 2, na.rm = TRUE)
+    }
   }
-  if (method==3) {
-    z <- sum(
-      ifelse(
-
-        x > tmax    &
-        lag(y) > 0  &
-        y > 0       &
-        lag(y) != y,
-
-        (x-lag(x))*(y-lag(y))/log(y/lag(y)),
-        (x-lag(x))*(y+lag(y))/2
-      ),
-      na.rm=T
-    )
+  if (method == 3) {
+    dx <- diff(x)
+    y2 <- y[-1]
+    y1 <- y[-length(y)]
+    logidx <- which(x[-1] > tmax & y1 > 0 & y2 > 0 & y1 != y2)
+    linidx <- setdiff(seq_along(dx), logidx)
+    z <- 0
+    if (length(logidx)) {
+      z <- z + sum(dx[logidx] * (y2[logidx] - y1[logidx]) / log(y2[logidx]/y1[logidx]), na.rm = TRUE)
+    }
+    if (length(linidx)) {
+      z <- z + sum(dx[linidx] * (y2[linidx] + y1[linidx]) / 2, na.rm = TRUE)
+    }
   }
 
   return(z)

--- a/R/trapm.r
+++ b/R/trapm.r
@@ -16,20 +16,48 @@
 trapm=function(x=NA, y=NA, method=1) {
   cm=max(y,na.rm=T)
   tmax=first(x[y==cm&!is.na(y)])
-  if (method==1)   {
-    z=  sum((x-lag(x))*(y*x+lag(y)*lag(x))/2,na.rm=T)
+  if (method == 1) {
+    z <- sum((x - lag(x)) * (y * x + lag(y) * lag(x)) / 2, na.rm = TRUE)
   }
-  if (method==2) {
-    z=  sum(ifelse(lag(y)>y&lag(y)>0&y>0,
-                   (x-lag(x))*(y*x-lag(y)*lag(x))/log(y/lag(y))-(x-lag(x))^2*(y-lag(y))/(log(y/lag(y)))^2,
-                   (x-lag(x))*(y*x+lag(y)*lag(x))/2
-    ),na.rm=T)
+  if (method == 2) {
+    dx <- diff(x)
+    y2 <- y[-1]
+    y1 <- y[-length(y)]
+    x2 <- x[-1]
+    x1 <- x[-length(x)]
+    down <- which(y1 > y2 & y1 > 0 & y2 > 0)
+    up <- setdiff(seq_along(dx), down)
+    z <- 0
+    if (length(down)) {
+      z <- z + sum(dx[down] * (y2[down] * x2[down] - y1[down] * x1[down]) /
+                    log(y2[down]/y1[down]) -
+                    dx[down]^2 * (y2[down] - y1[down]) / (log(y2[down]/y1[down]))^2,
+                  na.rm = TRUE)
+    }
+    if (length(up)) {
+      z <- z + sum(dx[up] * (y2[up] * x2[up] + y1[up] * x1[up]) / 2, na.rm = TRUE)
+    }
   }
-  if (method==3) {
-    z=  sum(ifelse(x>tmax&lag(y)>0&y>0&lag(y)!=y,
-                   (x-lag(x))*(y*x-lag(y)*lag(x))/log(y/lag(y))-(x-lag(x))^2*(y-lag(y))/(log(y/lag(y)))^2,
-                   (x-lag(x))*(y*x+lag(y)*lag(x))/2
-    ),na.rm=T)
+  if (method == 3) {
+    dx <- diff(x)
+    y2 <- y[-1]
+    y1 <- y[-length(y)]
+    x2 <- x[-1]
+    x1 <- x[-length(x)]
+    logidx <- which(x2 > tmax & y1 > 0 & y2 > 0 & y1 != y2)
+    linidx <- setdiff(seq_along(dx), logidx)
+    z <- 0
+    if (length(logidx)) {
+      z <- z + sum(dx[logidx] * (y2[logidx] * x2[logidx] - y1[logidx] * x1[logidx]) /
+                    log(y2[logidx]/y1[logidx]) -
+                    dx[logidx]^2 * (y2[logidx] - y1[logidx]) /
+                      (log(y2[logidx]/y1[logidx]))^2,
+                  na.rm = TRUE)
+    }
+    if (length(linidx)) {
+      z <- z + sum(dx[linidx] * (y2[linidx] * x2[linidx] + y1[linidx] * x1[linidx]) / 2,
+                  na.rm = TRUE)
+    }
   }
 
   return(z)


### PR DESCRIPTION
## Summary
- avoid evaluating `log()` on invalid points in `trap` and `trapm`

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_b_68416f79bed8832cb6480a25e45a314b